### PR TITLE
Changed the default return value for methods that return a collection interface to return an instance of an empty collection

### DIFF
--- a/Rhino.Mocks.Tests/StubTest.cs
+++ b/Rhino.Mocks.Tests/StubTest.cs
@@ -27,6 +27,7 @@
 #endregion
 
 using System;
+using System.Collections.Generic;
 using Xunit;
 using Rhino.Mocks.Interfaces;
 
@@ -57,6 +58,17 @@ namespace Rhino.Mocks.Tests
 			Assert.Null(animal.Species);
 			animal.Species = "Caucasusian Shepherd";
 			Assert.Equal("Caucasusian Shepherd", animal.Species);
+		}
+
+		[Fact]
+		public void DefaultValue_OfAMethodThatHasNoExpectationsAndReturnACollection_ReturnAnEmptyCollection()
+		{
+			var animal = MockRepository.GenerateStub<IAnimal>();
+
+			var parents = animal.GetParents();
+
+			Assert.NotNull(parents);
+			Assert.Equal(0, parents.Count);
 		}
 
 		[Fact]
@@ -132,6 +144,8 @@ namespace Rhino.Mocks.Tests
 
 		event EventHandler Hungry;
 		string GetMood();
+
+		IList<IAnimal> GetParents();
 	}
 
 	public class SomeClass

--- a/Rhino.Mocks.Tests/Utilities/ReturnValueUtilTests.cs
+++ b/Rhino.Mocks.Tests/Utilities/ReturnValueUtilTests.cs
@@ -26,9 +26,10 @@
 // THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #endregion
 
-
+using System.Collections;
 using Xunit;
 using Rhino.Mocks.Utilities;
+using System.Collections.Generic;
 
 namespace Rhino.Mocks.Tests.Utilities
 {
@@ -38,6 +39,7 @@ namespace Rhino.Mocks.Tests.Utilities
 		[Fact]
 		public void DefaultReturnValue()
 		{
+			Assert.Null(ReturnValueUtil.DefaultValue(typeof(void), null));
 			Assert.Null(ReturnValueUtil.DefaultValue(typeof (string),null));
 			Assert.Equal(0, ReturnValueUtil.DefaultValue(typeof (int),null));
 			Assert.Equal((short) 0, ReturnValueUtil.DefaultValue(typeof (short),null));
@@ -48,10 +50,63 @@ namespace Rhino.Mocks.Tests.Utilities
 			Assert.Equal(TestEnum.DefaultValue, ReturnValueUtil.DefaultValue(typeof (TestEnum),null));
 		}
 
+		[Fact]
+		public void DefaultReturnValue_WhenTheReturnTypeIsACollectionInterface_ReturnAnEmptyCollection()
+		{
+			Assert.NotNull(ReturnValueUtil.DefaultValue(typeof (IEnumerable), null) as IEnumerable);
+
+			var defaultValueForCollections = ReturnValueUtil.DefaultValue(typeof (ICollection), null) as ICollection;
+			Assert.NotNull(defaultValueForCollections);
+			Assert.Equal(0, defaultValueForCollections.Count);
+
+			var defaultValueForLists = ReturnValueUtil.DefaultValue(typeof (IList), null) as IList;
+			Assert.NotNull(defaultValueForLists);
+			Assert.Equal(0, defaultValueForLists.Count);
+
+			var defaultValueForDictionaries = ReturnValueUtil.DefaultValue(typeof (IDictionary), null) as IDictionary;
+			Assert.NotNull(defaultValueForDictionaries);
+			Assert.Equal(0, defaultValueForDictionaries.Keys.Count);
+			Assert.Equal(0, defaultValueForDictionaries.Values.Count);
+		}
+
+		[Fact]
+		public void DefaultReturnValue_WhenTheReturnTypeIsAGenericCollectionInterface_ReturnAnEmptyCollection()
+		{
+			var defValForGenericEnumerable = ReturnValueUtil.DefaultValue(typeof (IEnumerable<IFoo>), null);
+			Assert.NotNull(defValForGenericEnumerable);
+
+			var defValForAGenericCollection = ReturnValueUtil.DefaultValue(typeof (ICollection<IFoo>), null) as ICollection<IFoo>;
+			Assert.NotNull(defValForAGenericCollection);
+			Assert.Equal(0, defValForAGenericCollection.Count);
+
+			var defValForAGenericList = ReturnValueUtil.DefaultValue(typeof (IList<IFoo>), null) as IList<IFoo>;
+			Assert.NotNull(defValForAGenericList);
+			Assert.Equal(0, defValForAGenericList.Count);
+
+			var defValForAGenericDictionary =
+				ReturnValueUtil.DefaultValue(typeof (IDictionary<IFoo, TestEnum>), null) as IDictionary<IFoo, TestEnum>;
+			Assert.NotNull(defValForAGenericDictionary);
+			Assert.Equal(0, defValForAGenericDictionary.Keys.Count);
+			Assert.Equal(0, defValForAGenericDictionary.Values.Count);
+		}
+
+		[Fact]
+		public void DefaultReturnValue_WhenTheReturnTypeImplementsAdditionalsInterfacesToIEnumerable_ReturnNull()
+		{
+			object defVal = ReturnValueUtil.DefaultValue(typeof (IFoo), null);
+
+			Assert.Null(defVal);
+		}
+
 		private enum TestEnum
 		{
 			DefaultValue,
 			NonDefaultValue
+		}
+
+		public interface IFoo : IEnumerable
+		{
+			string Bar { get; set; }
 		}
 	}
 }


### PR DESCRIPTION
This change tries to reduce the number of methods stubs needed to stub an object.

The reason why we use a stub is to communicate that the object is needed but does not act for the purpose that we want to test.

Currently, if there is a call to a method of a stub that returns a collection, the stub object will return a null that will probably cause a null reference exception.
We will have to add a stub espectation for the method even if it does not act on what we want to test.

It is usual that the real implementation of a method that return a collection, return a empty collection instead of a null.

Therefore, if the stub object returns an empty collection instead of a null, will be more similar to the real behavior of the real class, and in addition, it will prevent the need of additional stub calls.
