### PR TITLE
IEqualityComparer for Validate

### DIFF
--- a/Rhino.Mocks.Tests/Impl/ValidateTests.cs
+++ b/Rhino.Mocks.Tests/Impl/ValidateTests.cs
@@ -36,7 +36,64 @@ namespace Rhino.Mocks.Tests.Impl
 {
 	
 	public class ValidateTests
-	{
+    {
+        private class AllObjectsCreatedEqualEqualityComparerImpl : IEqualityComparer
+        {
+            #region Implementation of IEqualityComparer
+
+            /// <summary>
+            /// Determines whether the specified objects are equal.
+            /// </summary>
+            /// <returns>
+            /// true if the specified objects are equal; otherwise, false.
+            /// </returns>
+            /// <param name="x">The first object to compare.
+            ///                 </param><param name="y">The second object to compare.
+            ///                 </param><exception cref="T:System.ArgumentException"><paramref name="x"/> and <paramref name="y"/> are of different types and neither one can handle comparisons with the other.
+            ///                 </exception>
+            public bool Equals(object x, object y)
+            {
+                return true;
+            }
+
+            /// <summary>
+            /// Returns a hash code for the specified object.
+            /// </summary>
+            /// <returns>
+            /// A hash code for the specified object.
+            /// </returns>
+            /// <param name="obj">The <see cref="T:System.Object"/> for which a hash code is to be returned.
+            ///                 </param><exception cref="T:System.ArgumentNullException">The type of <paramref name="obj"/> is a reference type and <paramref name="obj"/> is null.
+            ///                 </exception>
+            public int GetHashCode(object obj)
+            {
+                throw new NotImplementedException();
+            }
+
+            #endregion
+        }
+
+        [Fact]
+        public void ValidateUseEqualityComparerIfNotNull()
+        {
+            string string1 = "string1";
+            string string2 = "string2";
+
+            Assert.False(Validate.AreEqual(string1, string2));
+
+            try
+            {
+                // Implementation isn't important here. Just want to know that it gets called
+                Validate.EqualityComparer = new AllObjectsCreatedEqualEqualityComparerImpl();
+
+                Assert.True(Validate.AreEqual(string1, string2));
+            }
+            finally
+            {
+                Validate.EqualityComparer = null;
+            }
+        }
+
 		[Fact]
 		public void IsNotNullWhenNotNull()
 		{

--- a/Rhino.Mocks/Impl/Validate.cs
+++ b/Rhino.Mocks/Impl/Validate.cs
@@ -33,52 +33,59 @@ using System.Collections;
 
 namespace Rhino.Mocks.Impl
 {
-	/// <summary>
-	/// Validate arguments for methods
-	/// </summary>
-	public static class Validate
-	{
-		/// <summary>
-		/// Validate that the passed argument is not null.
-		/// </summary>
-		/// <param name="obj">The object to validate</param>
-		/// <param name="name">The name of the argument</param>
-		/// <exception cref="ArgumentNullException">
-		/// If the obj is null, an ArgumentNullException with the passed name
-		/// is thrown.
-		/// </exception>
-		public static void IsNotNull(object obj, string name)
-		{
-			if (obj == null)
-				throw new ArgumentNullException(name);
-		}
+    /// <summary>
+    /// Validate arguments for methods
+    /// </summary>
+    public static class Validate
+    {
+        /// <summary>
+        /// Gets or sets the equality comparer tha is used for testing the equality of two instances.
+        /// </summary>
+        /// <remarks>If this is <c>null</c> then default equality is used.</remarks>
+        /// <value>The equality comparer.</value>
+        public static IEqualityComparer EqualityComparer { get; set; }
 
-		/// <summary>
-		/// Validate that the arguments are equal.
-		/// </summary>
-		/// <param name="expectedArgs">Expected args.</param>
-		/// <param name="actualArgs">Actual Args.</param>
-		public static bool ArgsEqual(object[] expectedArgs, object[] actualArgs)
-		{
-			return RecursiveCollectionEqual(expectedArgs, actualArgs);
-		}
+        /// <summary>
+        /// Validate that the passed argument is not null.
+        /// </summary>
+        /// <param name="obj">The object to validate</param>
+        /// <param name="name">The name of the argument</param>
+        /// <exception cref="ArgumentNullException">
+        /// If the obj is null, an ArgumentNullException with the passed name
+        /// is thrown.
+        /// </exception>
+        public static void IsNotNull(object obj, string name)
+        {
+            if (obj == null)
+                throw new ArgumentNullException(name);
+        }
 
-		/// <summary>
-		/// Validate that the two arguments are equals, including validation for
-		/// when the arguments are collections, in which case it will validate their values.
-		/// </summary>
-		public static bool AreEqual(object expectedArg, object actualArg)
-		{
-			return RecursiveCollectionEqual(new object[] { expectedArg }, new object[] { actualArg });
-		}
+        /// <summary>
+        /// Validate that the arguments are equal.
+        /// </summary>
+        /// <param name="expectedArgs">Expected args.</param>
+        /// <param name="actualArgs">Actual Args.</param>
+        public static bool ArgsEqual(object[] expectedArgs, object[] actualArgs)
+        {
+            return RecursiveCollectionEqual(expectedArgs, actualArgs);
+        }
 
-		#region Implementation
+        /// <summary>
+        /// Validate that the two arguments are equals, including validation for
+        /// when the arguments are collections, in which case it will validate their values.
+        /// </summary>
+        public static bool AreEqual(object expectedArg, object actualArg)
+        {
+            return RecursiveCollectionEqual(new object[] { expectedArg }, new object[] { actualArg });
+        }
+
+        #region Implementation
 
         private static bool RecursiveCollectionEqual(ICollection expectedArgs, ICollection actualArgs)
         {
-            if(expectedArgs == null && actualArgs == null)
+            if (expectedArgs == null && actualArgs == null)
                 return true;
-            if(expectedArgs==null || actualArgs==null)
+            if (expectedArgs == null || actualArgs == null)
                 return false;
 
             if (expectedArgs.Count != actualArgs.Count)
@@ -126,13 +133,18 @@ namespace Rhino.Mocks.Impl
             //none are mocked object
             if (expectedMock == null && actualMock == null)
             {
+                if (EqualityComparer != null)
+                {
+                    return EqualityComparer.Equals(expected, actual);
+                }
+
                 return expected.Equals(actual);
             }
             //if any of them is a mocked object, use mocks equality
             //this may not be what the user is expecting, but it is needed, because
             //otherwise we get into endless loop.
-            return MockedObjectsEquality.Instance.Equals(expected,actual);
+            return MockedObjectsEquality.Instance.Equals(expected, actual);
         }
-		#endregion
-	}
+        #endregion
+    }
 }


### PR DESCRIPTION
This patch gives the developer the ability to add their own IEqualityComparer instance to the Validate class so that custom equality comparison can be used as needed. The default is left as is.
