### PR TITLE
Pull request related to https://groups.google.com/forum/#!topic/rhinomocks/xRsAtAPYjmk/discussion

### DIFF
--- a/Rhino.Mocks.Tests/FieldsProblem/UsingEvents.cs
+++ b/Rhino.Mocks.Tests/FieldsProblem/UsingEvents.cs
@@ -248,6 +248,28 @@ namespace Rhino.Mocks.Tests.FieldsProblem
 		}
 #endif
 
+        [Fact]
+        public void UsingEventRaiserWithNullableArgumentInEvent()
+        {
+            IWithNullableArgsEvents eventHolder = (IWithNullableArgsEvents)mocks.Stub(typeof(IWithNullableArgsEvents));
+            IEventRaiser eventRaiser = eventHolder.GetEventRaiser(stub => stub.Foo += null);
+
+            mocks.ReplayAll();
+
+            bool called = false;
+            eventHolder.Foo += delegate
+            {
+                called = true;
+            };
+
+
+            eventRaiser.Raise(default(int?));
+
+            mocks.VerifyAll();
+
+            Assert.True(called);
+        }
+
 	}
 
 	public interface IWithEvents
@@ -276,4 +298,9 @@ namespace Rhino.Mocks.Tests.FieldsProblem
 		#endregion
 	}
 
+    public interface IWithNullableArgsEvents
+    {
+        event Action<int?> Foo;
+        void RaiseEvent();
+    }
 }

--- a/Rhino.Mocks/Impl/EventRaiser.cs
+++ b/Rhino.Mocks/Impl/EventRaiser.cs
@@ -111,7 +111,7 @@ namespace Rhino.Mocks.Impl
 			List<string> errors = new List<string>();
 			for (int i = 0; i < parameterInfos.Length; i++)
 			{
-				if ((args[i] == null && parameterInfos[i].ParameterType.IsValueType) ||
+                if ((args[i] == null && !NullIsValidValueFor(parameterInfos[i].ParameterType)) ||
 					(args[i] != null && parameterInfos[i].ParameterType.IsInstanceOfType(args[i])==false))
 				{
 					string type = "null";
@@ -127,7 +127,18 @@ namespace Rhino.Mocks.Impl
 			}
 		}
 
-		/// <summary>
+	    private static bool NullIsValidValueFor(Type type)
+	    {
+            if (!type.IsValueType)
+                return true;
+
+            if (Nullable.GetUnderlyingType(type) != null)
+                return true;
+
+	        return false;
+	    }
+
+	    /// <summary>
 		/// The most common signature for events
 		/// Here to allow intellisense to make better guesses about how 
 		/// it should suggest parameters.


### PR DESCRIPTION
EventRaiser.AssertMatchingParameters ignores null as a valid value for
nullable types hence throws with a message similar to this "Parameter #4
is null but should be System.Nullable`1[System.Double]"
