### PR TITLE
Generic Constraints, which allows for an extra helper method with type inference

### DIFF
--- a/Rhino.Mocks/Arg.cs
+++ b/Rhino.Mocks/Arg.cs
@@ -136,6 +136,16 @@ namespace Rhino.Mocks
 		{
 			return Arg<T>.Is.Equal(arg);
 		}
+
+        public static T Matches<T>(Expression<Predicate<T>> predicate)
+        {
+            return Arg<T>.Matches(predicate);
+        }
+
+        public static T Matches<T>(AbstractConstraint<T> constraint)
+        {
+            return Arg<T>.Matches(constraint);
+        }
 	}
 }
 

--- a/Rhino.Mocks/Constraints/AbstractConstraint.cs
+++ b/Rhino.Mocks/Constraints/AbstractConstraint.cs
@@ -89,4 +89,27 @@ namespace Rhino.Mocks.Constraints
 			return false;
 		}
 	}
+
+    ///<summary>
+    /// Interface for constraints that match a type
+    ///</summary>
+    ///<typeparam name="T">Type of the Argument</typeparam>
+    public abstract class AbstractConstraint<T> : AbstractConstraint
+    {
+        public override bool Eval(object obj)
+        {
+            if (obj is T)
+            {
+                return Eval((T) obj);
+            }
+            return false;
+        }
+
+        ///<summary>
+        /// Determines if the object pass the constraints
+        ///</summary>
+        ///<param name="obj">object to evaluate</param>
+        ///<returns></returns>
+        public abstract bool Eval(T obj);
+    }
 }


### PR DESCRIPTION
Arg.Is() is very useful, but I wanted a similar one which would do Arg.Matches(), using type inference so that I wouldn't have to do Arg<T>.Matches().

In order to do this I needed to create a Constraint<T> class which subclasses Constraint.

It's a tiny change, but it makes writing complex Arg-based expectations a lot simpler.

Arg<Dictionary<string, string>>.Matches(Holds.SameDataAs(GetHeaders()))
becomes
Arg.Matches(Holds.SameDataAs(GetHeaders()))