### PR TITLE
Doc comment typo fixes

### DIFF
--- a/Rhino.Mocks/Arg.cs
+++ b/Rhino.Mocks/Arg.cs
@@ -62,7 +62,7 @@ namespace Rhino.Mocks
 		/// <summary>
 		/// Define a simple constraint for this argument. (Use Matches in simple cases.)
 		/// Example: 
-		///   Arg&lt;int&gt;.Is.Anthing
+		///   Arg&lt;int&gt;.Is.Anything
 		///   Arg&lt;string&gt;.Is.Equal("hello")
 		/// </summary>
 		public static IsArg<T> Is { get { return new IsArg<T>(); } }

--- a/Rhino.Mocks/Constraints/Is.cs
+++ b/Rhino.Mocks/Constraints/Is.cs
@@ -49,7 +49,7 @@ namespace Rhino.Mocks.Constraints
 		 * The parameter must implement IComparable 
 		 */ 
 		/// <summary>
-		/// Evaluate a greater than constraint for <see cref="IComparable"/>.
+		/// Evaluate a greater-than constraint for <see cref="IComparable"/>.
 		/// </summary>
 		/// <param name="objToCompare">The object the parameter should be greater than</param>
 		public static AbstractConstraint GreaterThan(IComparable objToCompare)
@@ -64,7 +64,7 @@ namespace Rhino.Mocks.Constraints
 		 * The parameter must implement IComparable 
 		 */ 
 		/// <summary>
-		/// Evaluate a less than constraint for <see cref="IComparable"/>.
+		/// Evaluate a less-than constraint for <see cref="IComparable"/>.
 		/// </summary>
 		/// <param name="objToCompare">The object the parameter should be less than</param>
 		public static AbstractConstraint LessThan(IComparable objToCompare)
@@ -79,7 +79,7 @@ namespace Rhino.Mocks.Constraints
 		* The parameter must implement IComparable 
 		*/ 
 		/// <summary>
-		/// Evaluate a less than or equal constraint for <see cref="IComparable"/>.
+		/// Evaluate a less-than-or-equal constraint for <see cref="IComparable"/>.
 		/// </summary>
 		/// <param name="objToCompare">The object the parameter should be less than or equal to</param>
 		public static AbstractConstraint LessThanOrEqual(IComparable objToCompare)
@@ -94,7 +94,7 @@ namespace Rhino.Mocks.Constraints
 		* The parameter must implement IComparable 
 		*/ 
 		/// <summary>
-		/// Evaluate a greater than or equal constraint for <see cref="IComparable"/>.
+		/// Evaluate a greater-than-or-equal constraint for <see cref="IComparable"/>.
 		/// </summary>
 		/// <param name="objToCompare">The object the parameter should be greater than or equal to</param>
 		public static AbstractConstraint GreaterThanOrEqual(IComparable objToCompare)
@@ -132,7 +132,7 @@ namespace Rhino.Mocks.Constraints
 		}
 
         /// <summary>
-        /// Evaluate a same as constraint.
+        /// Evaluate a same-as constraint.
         /// </summary>
         /// <param name="obj">The object the parameter should the same as.</param>
         public static AbstractConstraint Same(object obj)
@@ -141,7 +141,7 @@ namespace Rhino.Mocks.Constraints
         }
 
         /// <summary>
-        /// Evaluate a not same as constraint.
+        /// Evaluate a not-same-as constraint.
         /// </summary>
         /// <param name="obj">The object the parameter should not be the same as.</param>
         public static AbstractConstraint NotSame(object obj)
@@ -155,7 +155,7 @@ namespace Rhino.Mocks.Constraints
 		 * This constraint always succeeds
 		 */ 
 		/// <summary>
-		/// A constraints that accept anything
+		/// A constraint that accepts anything
 		/// </summary>
 		/// <returns></returns>
 		public static AbstractConstraint Anything()
@@ -170,7 +170,7 @@ namespace Rhino.Mocks.Constraints
 		 * 
 		 */
 		/// <summary>
-		/// A constraint that accept only nulls
+		/// A constraint that accepts only nulls
 		/// </summary>
 		/// <returns></returns>
 		public static AbstractConstraint Null()
@@ -185,7 +185,7 @@ namespace Rhino.Mocks.Constraints
 		 * 
 		 */
 		/// <summary>
-		/// A constraint that accept only non null values
+		/// A constraint that accepts only non null values
 		/// </summary>
 		/// <returns></returns>
 		public static AbstractConstraint NotNull()
@@ -200,7 +200,7 @@ namespace Rhino.Mocks.Constraints
 		 * 
 		 */
 		/// <summary>
-		/// A constraint that accept only value of the specified type
+		/// A constraint that accepts only value of the specified type
 		/// </summary>
 		public static AbstractConstraint TypeOf(Type type)
 		{
@@ -214,7 +214,7 @@ namespace Rhino.Mocks.Constraints
 		 * 
 		 */
         /// <summary>
-        /// A constraint that accept only value of the specified type
+        /// A constraint that accepts only value of the specified type
         /// </summary>
 		public static AbstractConstraint TypeOf<T>()
 		{

--- a/Rhino.Mocks/Constraints/Is.cs
+++ b/Rhino.Mocks/Constraints/Is.cs
@@ -166,7 +166,7 @@ namespace Rhino.Mocks.Constraints
 		/*
 		 * Method: Null
 		 * 
-		 * Determines whatever the parameter is null
+		 * Whatever the parameter, as long as it is null
 		 * 
 		 */
 		/// <summary>
@@ -181,7 +181,7 @@ namespace Rhino.Mocks.Constraints
 		/*
 		 * Method: NotNull
 		 * 
-		 * Determines whatever the parameter is not null
+		 * Whatever parameter, as long as it is not null
 		 * 
 		 */
 		/// <summary>
@@ -196,11 +196,11 @@ namespace Rhino.Mocks.Constraints
 		/*
 		 * Method: TypeOf
 		 * 
-		 * Determines whatever the parameter if of the specified type.
+		 * Whatever parameter, as long as it is of the specified type.
 		 * 
 		 */
 		/// <summary>
-		/// A constraint that accepts only value of the specified type
+		/// A constraint that accepts only values of the specified type
 		/// </summary>
 		public static AbstractConstraint TypeOf(Type type)
 		{
@@ -210,11 +210,11 @@ namespace Rhino.Mocks.Constraints
         /*
 		 * Method: TypeOf
 		 * 
-		 * Determines whatever the parameter if of the specified type.
+		 * Whatever parameter, as long as it is of the specified type.
 		 * 
 		 */
         /// <summary>
-        /// A constraint that accepts only value of the specified type
+        /// A constraint that accepts only values of the specified type
         /// </summary>
 		public static AbstractConstraint TypeOf<T>()
 		{

--- a/Rhino.Mocks/Constraints/IsArg.cs
+++ b/Rhino.Mocks/Constraints/IsArg.cs
@@ -34,7 +34,7 @@ namespace Rhino.Mocks.Constraints
 {
 
 	/// <summary>
-	/// Provides access to the constraintes defined in the class <see cref="Is"/> to be used in context
+	/// Provides access to the constraints defined in the class <see cref="Is"/> to be used in context
 	/// with the <see cref="Arg&lt;T&gt;"/> syntax.
 	/// </summary>
 	/// <typeparam name="T">The type of the argument</typeparam>
@@ -45,7 +45,7 @@ namespace Rhino.Mocks.Constraints
 
 
 		/// <summary>
-		/// Evaluate a greater than constraint for <see cref="IComparable"/>.
+		/// Evaluate a greater-than constraint for <see cref="IComparable"/>.
 		/// </summary>
 		/// <param name="objToCompare">The object the parameter should be greater than</param>
 		public T GreaterThan(IComparable objToCompare)
@@ -56,7 +56,7 @@ namespace Rhino.Mocks.Constraints
 		}
 
 		/// <summary>
-		/// Evaluate a less than constraint for <see cref="IComparable"/>.
+		/// Evaluate a less-than constraint for <see cref="IComparable"/>.
 		/// </summary>
 		/// <param name="objToCompare">The object the parameter should be less than</param>
 		public T LessThan(IComparable objToCompare)
@@ -67,7 +67,7 @@ namespace Rhino.Mocks.Constraints
 		}
 
 		/// <summary>
-		/// Evaluate a less than or equal constraint for <see cref="IComparable"/>.
+		/// Evaluate a less-than-or-equal constraint for <see cref="IComparable"/>.
 		/// </summary>
 		/// <param name="objToCompare">The object the parameter should be less than or equal to</param>
 		public T LessThanOrEqual(IComparable objToCompare)
@@ -78,7 +78,7 @@ namespace Rhino.Mocks.Constraints
 		}
 
 		/// <summary>
-		/// Evaluate a greater than or equal constraint for <see cref="IComparable"/>.
+		/// Evaluate a greater-than-or-equal constraint for <see cref="IComparable"/>.
 		/// </summary>
 		/// <param name="objToCompare">The object the parameter should be greater than or equal to</param>
 		public T GreaterThanOrEqual(IComparable objToCompare)
@@ -163,7 +163,7 @@ namespace Rhino.Mocks.Constraints
 
 
 		/// <summary>
-		/// Evaluate a same as constraint.
+		/// Evaluate a same-as constraint.
 		/// </summary>
 		/// <param name="obj">The object the parameter should the same as.</param>
 		public T Same(object obj)
@@ -174,7 +174,7 @@ namespace Rhino.Mocks.Constraints
 		}
 
 		/// <summary>
-		/// Evaluate a not same as constraint.
+		/// Evaluate a not-same-as constraint.
 		/// </summary>
 		/// <param name="obj">The object the parameter should not be the same as.</param>
 		public T NotSame(object obj)
@@ -184,7 +184,7 @@ namespace Rhino.Mocks.Constraints
 		}
 
 		/// <summary>
-		/// A constraints that accept anything
+		/// A constraint that accepts anything
 		/// </summary>
 		/// <returns></returns>
 		public T Anything
@@ -197,7 +197,7 @@ namespace Rhino.Mocks.Constraints
 		}
 
 		/// <summary>
-		/// A constraint that accept only nulls
+		/// A constraint that accepts only nulls
 		/// </summary>
 		/// <returns></returns>
 		public T Null
@@ -210,7 +210,7 @@ namespace Rhino.Mocks.Constraints
 		}
 
 		/// <summary>
-		/// A constraint that accept only non null values
+		/// A constraint that accepts only non null values
 		/// </summary>
 		/// <returns></returns>
 		public T NotNull
@@ -223,7 +223,7 @@ namespace Rhino.Mocks.Constraints
 		}
 
 		/// <summary>
-		/// A constraint that accept only value of the specified type.
+		/// A constraint that accepts only values of the specified type.
 		/// The check is performed on the type that has been defined
 		/// as the argument type.
 		/// </summary>


### PR DESCRIPTION
I love Rhino but occasionally see Intellisense comments with typos, usually in the constraints.

I wanted to give back and clean up the comments a bit for grammar and spelling. Please keep up the good work!